### PR TITLE
Utökad fältskrivning till InfluxDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # MEXC WebSocket to InfluxDB
 
-Real-time streaming of trades from MEXC to InfluxDB using WebSocket.
+Real-time streaming of trades and balances from MEXC to InfluxDB.
+
+### Trades
+
+Mätningen `mexc_trade` innehåller nu även:
+
+- `tradeId`
+- `orderId`
+- `quoteQty`
+- `commission`
+- `commissionAsset`
+- `time`
+
+### Balans
+
+Mätningen `mexc_balance` lagrar fälten `asset`, `free` och `locked` för varje tillgång.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Sammanfattning
- la till fler detaljer i trades och balansdata
- uppdaterade README med nya fält

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68656f940a40832ab8dce98028f36e37