### PR TITLE
Uppdaterad README om tradefält

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Real-time streaming of trades and balances from MEXC to InfluxDB.
 
 ### Trades
 
-Mätningen `mexc_trade` innehåller nu även:
+Mätningen `mexc_trade` lagrar endast de fält som faktiskt skrivs in av koden:
 
-- `tradeId`
-- `orderId`
-- `quoteQty`
-- `commission`
-- `commissionAsset`
-- `time`
+- taggarna `symbol` och `side`
+- fälten `price` och `volume`
+- tidsstämpeln från `time`
+
+Ingen PnL räknas automatiskt. Vill du följa vinst och förlust behöver du
+beräkna detta separat eller använda andra API-endpoints.
 
 ### Balans
 


### PR DESCRIPTION
## Sammanfattning
- uppdatera README så att den matchar de faktiska fälten i `mexc_trade`
- förtydliga att PnL inte loggas automatiskt

## Test
- `python -m py_compile main.py`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_6869a97ac100832aab55581b1c3ea109